### PR TITLE
Vacation 도메인 테이블 구조 변경에 따른 소스 및 테스트 코드 수정 

### DIFF
--- a/vacation-api/src/main/java/com/jxx/vacation/api/vacation/application/VacationAdminService.java
+++ b/vacation-api/src/main/java/com/jxx/vacation/api/vacation/application/VacationAdminService.java
@@ -59,16 +59,15 @@ public class VacationAdminService {
         UserSession userSession = vacationServiceForm.userSession();
         CommonVacationForm commonVacationForm = vacationServiceForm.commonVacationForm();
         List<LocalDate> vacationDates = commonVacationForm.vacationDates();
-        boolean deducted = vacationServiceForm.commonVacationForm().deducted();
 
         List<Vacation> vacations = new ArrayList<>();
         for (LocalDate vacationDate : vacationDates) {
             Vacation commonVacation = Vacation.builder()
-                    .deducted(deducted)
                     .vacationStatus(VacationStatus.CREATE)
+                    .vacationType(VacationType.COMMON_VACATION)
                     .requesterId(userSession.getMemberId()) // check
                     .companyId(commonVacationForm.companyId())
-                    .vacationDuration(new VacationDuration(VacationType.COMMON_VACATION, vacationDate.atStartOfDay(), vacationDate.atTime(23, 59, 59)))
+//                    .vacationDurations(List.of(new VacationDuration(vacationDate.atStartOfDay(), vacationDate.atTime(23, 59, 59), 1f)))
                     .build();
 
             vacations.add(commonVacation);

--- a/vacation-api/src/main/java/com/jxx/vacation/api/vacation/application/VacationService.java
+++ b/vacation-api/src/main/java/com/jxx/vacation/api/vacation/application/VacationService.java
@@ -29,6 +29,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Comparator;
 import java.util.List;
 import java.util.function.BiFunction;
 
@@ -63,11 +64,21 @@ public class VacationService {
         Vacation vacation = vacationManager.getVacation();
         List<VacationDuration> vacationDurations = vacationForm.requestVacationDurations().stream()
                 .map(rvd -> new VacationDuration(rvd.startDateTime(), rvd.endDateTime(), vacationForm.leaveDeduct()))
+                .sorted(VacationDuration::sortByEndDateTime)
                 .toList();
+
+        log.info("vacationDurations", vacationDurations);
+
+        // lastVacationDuration 는 위 vacationDurations 요소이다. List는 참조값을 바라보기 때문에 요소를 꺼내서 변경해도 반영된다.
+        // 혼란스러울 수 있기에 주석...
+        int lastVacationDurationIndex = vacationDurations.size() - 1;
+        VacationDuration lastVacationDuration = vacationDurations.get(lastVacationDurationIndex);
+        lastVacationDuration.changeLastDuration();
 
         for (VacationDuration vacationDuration : vacationDurations) {
             vacationDuration.mappingVacation(vacation);
         }
+
         vacationDurationRepository.saveAll(vacationDurations);
         final Vacation savedVacation = vacationRepository.save(vacation);
 

--- a/vacation-api/src/main/java/com/jxx/vacation/api/vacation/application/VacationService.java
+++ b/vacation-api/src/main/java/com/jxx/vacation/api/vacation/application/VacationService.java
@@ -62,8 +62,7 @@ public class VacationService {
 
         Vacation vacation = vacationManager.getVacation();
         List<VacationDuration> vacationDurations = vacationForm.requestVacationDurations().stream()
-                .map(rvd -> new VacationDuration(rvd.startDateTime(), rvd.endDateTime(),
-                        VacationCalculator.calculateUseLeaveValue(vacationForm.leaveDeduct(), rvd.startDateTime(), rvd.endDateTime())))
+                .map(rvd -> new VacationDuration(rvd.startDateTime(), rvd.endDateTime(), vacationForm.leaveDeduct()))
                 .toList();
 
         for (VacationDuration vacationDuration : vacationDurations) {

--- a/vacation-api/src/main/java/com/jxx/vacation/api/vacation/dto/request/RequestVacationForm.java
+++ b/vacation-api/src/main/java/com/jxx/vacation/api/vacation/dto/request/RequestVacationForm.java
@@ -1,12 +1,18 @@
 package com.jxx.vacation.api.vacation.dto.request;
 
-import com.jxx.vacation.core.vacation.domain.entity.VacationDuration;
+import com.jxx.vacation.core.vacation.domain.RequestVacationDuration;
+import com.jxx.vacation.core.vacation.domain.entity.LeaveDeduct;
+import com.jxx.vacation.core.vacation.domain.entity.VacationType;
 import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
 
 public record RequestVacationForm(
         @NotNull
         String requesterId,
-        VacationDuration vacationDuration
+        VacationType vacationType,
+        LeaveDeduct leaveDeduct,
+        List<RequestVacationDuration> requestVacationDurations
 
 ) {
 }

--- a/vacation-api/src/main/java/com/jxx/vacation/api/vacation/dto/response/VacationServiceResponse.java
+++ b/vacation-api/src/main/java/com/jxx/vacation/api/vacation/dto/response/VacationServiceResponse.java
@@ -1,13 +1,15 @@
 package com.jxx.vacation.api.vacation.dto.response;
 
-import com.jxx.vacation.core.vacation.domain.entity.VacationDuration;
+import com.jxx.vacation.core.vacation.domain.VacationDurationDto;
 import com.jxx.vacation.core.vacation.domain.entity.VacationStatus;
+
+import java.util.List;
 
 public record VacationServiceResponse(
         Long vacationId,
         String requesterId,
         String requesterName,
-        VacationDuration vacationDuration,
+        List<VacationDurationDto> vacationDuration,
         VacationStatus vacationStatus
 ) {
 }

--- a/vacation-api/src/main/java/com/jxx/vacation/api/vacation/presentation/VacationApiController.java
+++ b/vacation-api/src/main/java/com/jxx/vacation/api/vacation/presentation/VacationApiController.java
@@ -56,12 +56,12 @@ public class VacationApiController {
 
     /*** 결재 수정 API */
 
-    @PatchMapping("/api/vacations/{vacation-id}")
-    public ResponseEntity<?> updateVacation(@PathVariable(name = "vacation-id") Long vacationId,
-                                            @RequestBody RequestVacationForm requestVacationForm) {
-        VacationServiceResponse response = vacationService.updateVacation(vacationId, requestVacationForm);
-        return ResponseEntity.ok(response);
-    }
+//    @PatchMapping("/api/vacations/{vacation-id}")
+//    public ResponseEntity<?> updateVacation(@PathVariable(name = "vacation-id") Long vacationId,
+//                                            @RequestBody RequestVacationForm requestVacationForm) {
+//        VacationServiceResponse response = vacationService.updateVacation(vacationId, requestVacationForm);
+//        return ResponseEntity.ok(response);
+//    }
 
     /*** 휴가 취소 API
      * 1. 추가 요구 사항 - 결재가 올라간 휴가를 취소할 경우, 결재 라인에 알려야 한다. */

--- a/vacation-api/src/main/resources/restapi/vacations.http
+++ b/vacation-api/src/main/resources/restapi/vacations.http
@@ -27,12 +27,15 @@ POST http://localhost:8080/api/vacations
 Content-Type: application/json
 
 {
-  "requesterId": "U00100",
-  "vacationDuration": {
-    "vacationType": "MORE_DAY",
-    "startDateTime": "2024-03-26T00:00",
-    "endDateTime": "2024-03-27T00:00"
-  }
+  "requesterId": "U00101",
+  "vacationType" : "MORE_DAY",
+  "leaveDeduct" : "DEDUCT",
+  "requestVacationDurations": [
+    {
+      "startDateTime": "2024-03-26T00:00",
+      "endDateTime": "2024-03-28T00:00"
+    }
+  ]
 }
 
 ###

--- a/vacation-api/src/main/resources/restapi/vacations.http
+++ b/vacation-api/src/main/resources/restapi/vacations.http
@@ -33,7 +33,7 @@ Content-Type: application/json
   "requestVacationDurations": [
     {
       "startDateTime": "2024-03-26T00:00",
-      "endDateTime": "2024-03-28T00:00"
+      "endDateTime": "2024-04-05T00:00"
     }
   ]
 }

--- a/vacation-api/src/main/resources/restapi/vacations.http
+++ b/vacation-api/src/main/resources/restapi/vacations.http
@@ -7,12 +7,15 @@ POST http://localhost:8080/api/vacations
 Content-Type: application/json
 
 {
-  "requesterId": "U00130",
-  "vacationDuration": {
-    "vacationType": "MORE_DAY",
-    "startDateTime": "2024-03-11T00:00",
-    "endDateTime": "2024-03-12T00:00"
-  }
+  "requesterId": "SPY00011",
+  "vacationType": "MORE_DAY",
+  "leaveDeduct": "DEDUCT",
+  "requestVacationDurations": [
+    {
+      "startDateTime": "2024-04-19T00:00",
+      "endDateTime": "2024-04-19T00:00"
+    }
+  ]
 }
 
 
@@ -27,13 +30,21 @@ POST http://localhost:8080/api/vacations
 Content-Type: application/json
 
 {
-  "requesterId": "U00101",
+  "requesterId": "U00050",
   "vacationType" : "MORE_DAY",
   "leaveDeduct" : "DEDUCT",
   "requestVacationDurations": [
     {
-      "startDateTime": "2024-03-26T00:00",
-      "endDateTime": "2024-04-05T00:00"
+      "startDateTime": "2024-04-19T00:00",
+      "endDateTime": "2024-04-19T00:00"
+    },
+    {
+      "startDateTime": "2024-04-24T00:00",
+      "endDateTime": "2024-04-24T00:00"
+    },
+    {
+      "startDateTime": "2024-04-22T00:00",
+      "endDateTime": "2024-04-22T00:00"
     }
   ]
 }

--- a/vacation-api/src/test/java/com/jxx/vacation/api/vacation/listener/VacationEventListenerTest.java
+++ b/vacation-api/src/test/java/com/jxx/vacation/api/vacation/listener/VacationEventListenerTest.java
@@ -57,13 +57,9 @@ class VacationEventListenerTest {
                 .enteredDate(LocalDate.of(2023, 5, 12))
                 .organization(new Organization("JXX","JX사","J001", "IT팀"))
                 .build();
+
         Vacation vacation = Vacation.builder()
-                .requesterId("U00100")
-                .vacationDuration(new VacationDuration(VacationType.MORE_DAY,
-                        LocalDateTime.of(2023, 5, 15, 0, 0),
-                        LocalDateTime.of(2023, 5, 17, 0, 0)))
                 .vacationStatus(VacationStatus.CREATE)
-                .deducted(true)
                 .leaveDeduct(LeaveDeduct.DEDUCT)
                 .build();
 

--- a/vacation-batch/src/main/java/com/jxx/vacation/batch/job/leave/item/LeaveItem.java
+++ b/vacation-batch/src/main/java/com/jxx/vacation/batch/job/leave/item/LeaveItem.java
@@ -63,8 +63,8 @@ public class LeaveItem {
     }
 
     public void calculateDeductAmount() {
-        VacationDuration vacationDuration = new VacationDuration(VacationType.valueOf(vacationType), startDateTime, endDateTime);
-        deductedAmount = VacationCalculator.getVacationDuration(vacationDuration, LeaveDeduct.valueOf(leaveDeduct));
+        VacationDuration vacationDuration = new VacationDuration(startDateTime, endDateTime, 4f);
+        deductedAmount = VacationCalculator.getVacationDuration(VacationType.valueOf(vacationType), vacationDuration, LeaveDeduct.valueOf(leaveDeduct));
     }
 
     public void updateVacationStatusToError() {

--- a/vacation-batch/src/main/java/com/jxx/vacation/batch/job/leave/item/LeaveItem.java
+++ b/vacation-batch/src/main/java/com/jxx/vacation/batch/job/leave/item/LeaveItem.java
@@ -63,7 +63,7 @@ public class LeaveItem {
     }
 
     public void calculateDeductAmount() {
-        VacationDuration vacationDuration = new VacationDuration(startDateTime, endDateTime, 4f);
+        VacationDuration vacationDuration = new VacationDuration(startDateTime, endDateTime, LeaveDeduct.valueOf(leaveDeduct));
         deductedAmount = VacationCalculator.getVacationDuration(VacationType.valueOf(vacationType), vacationDuration, LeaveDeduct.valueOf(leaveDeduct));
     }
 

--- a/vacation-batch/src/main/java/com/jxx/vacation/batch/job/leave/item/LeaveItem.java
+++ b/vacation-batch/src/main/java/com/jxx/vacation/batch/job/leave/item/LeaveItem.java
@@ -16,7 +16,6 @@ public class LeaveItem {
 
     private final String memberPk;
     private final LocalDateTime createTime;
-
     private final boolean memberActive;
     private final Float totalLeave;
     private final Float remainingLeave;
@@ -34,9 +33,10 @@ public class LeaveItem {
     private final String departmentId;
     private final boolean orgActive;
     private Float deductedAmount;
+    private final String lastDuration;
 
     public LeaveItem(String memberPk, LocalDateTime createTime, boolean memberActive, Float totalLeave, Float remainingLeave, String name, String memberId, Integer experienceYears, LocalDate enteredDate,
-                     Long vacationId, String leaveDeduct, String vacationStatus, String vacationType, LocalDateTime startDateTime, LocalDateTime endDateTime, String companyId, String departmentId, boolean orgActive) {
+                     Long vacationId, String leaveDeduct, String vacationStatus, String vacationType, LocalDateTime startDateTime, LocalDateTime endDateTime, String companyId, String departmentId, boolean orgActive, String lastDuration) {
         this.memberPk = memberPk;
         this.createTime = createTime;
         this.memberActive = memberActive;
@@ -55,6 +55,7 @@ public class LeaveItem {
         this.companyId = companyId;
         this.departmentId = departmentId;
         this.orgActive = orgActive;
+        this.lastDuration = lastDuration;
         this.deductedAmount = 0f;
     }
 

--- a/vacation-batch/src/main/java/com/jxx/vacation/batch/job/leave/processor/LeaveItemValidateProcessor.java
+++ b/vacation-batch/src/main/java/com/jxx/vacation/batch/job/leave/processor/LeaveItemValidateProcessor.java
@@ -17,6 +17,8 @@ public class LeaveItemValidateProcessor implements ItemProcessor<LeaveItem, Leav
         String memberId = item.getMemberId();
         String vacationStatus = item.getVacationStatus();
         Long vacationId = item.getVacationId();
+        String lastDuration = item.getLastDuration();
+
         if (!memberOrgActive) {
             log.info("[PROCESS VID:{}][FILTER][memberId:{} inactive][member {}, org {}]", vacationId, memberId, item.isMemberActive(), item.isOrgActive());
             return null;
@@ -25,6 +27,9 @@ public class LeaveItemValidateProcessor implements ItemProcessor<LeaveItem, Leav
             return null;
         } else if (!LeaveDeduct.DEDUCT.equals(LeaveDeduct.valueOf(item.getLeaveDeduct()))) {
             log.info("[PROCESS VID:{}][FILTER][memberId:{} companyId:{}][is set deducted value false]", vacationId, memberId, item.getCompanyId());
+            return null;
+        } else if (!"Y".equals(lastDuration)) {
+            log.info("[PROCESS VID:{}][FILTER][memberId:{} lastDuration:{}][lastDuration is Not Y]", vacationId, memberId, item.getLastDuration());
             return null;
         }
 

--- a/vacation-batch/src/main/java/com/jxx/vacation/batch/job/leave/reader/LeaveItemReaderFactory.java
+++ b/vacation-batch/src/main/java/com/jxx/vacation/batch/job/leave/reader/LeaveItemReaderFactory.java
@@ -1,0 +1,62 @@
+package com.jxx.vacation.batch.job.leave.reader;
+
+import com.jxx.vacation.batch.job.leave.item.LeaveItem;
+import com.jxx.vacation.core.common.converter.LocalDateTimeConverter;
+import org.springframework.batch.core.scope.context.JobContext;
+import org.springframework.batch.core.scope.context.JobSynchronizationManager;
+import org.springframework.batch.item.database.JdbcCursorItemReader;
+import org.springframework.batch.item.database.builder.JdbcCursorItemReaderBuilder;
+
+import javax.sql.DataSource;
+
+import static com.jxx.vacation.batch.job.parameters.JxxJobParameter.JOB_PARAM_EXECUTE_DATE_TIME;
+
+/**
+ * LeaveItem 필드 순으로 가져와야함
+ */
+public class LeaveItemReaderFactory {
+
+    private static final Long EXECUTE_DATE_TIME_ADJUST_VALUE = -1l;
+    public JdbcCursorItemReader<LeaveItem> leaveItemReader(DataSource dataSource) {
+        String sql = "SELECT " +
+                "JMLM.MEMBER_PK , " +
+                "JVM.CREATE_TIME , " +
+                "JMLM.REMAINING_LEAVE , " +
+                "JMLM.TOTAL_LEAVE , " +
+                "JMLM.NAME ," +
+                "JMLM.MEMBER_ID ," +
+                "JMLM.EXPERIENCE_YEARS ," +
+                "JMLM.IS_ACTIVE AS 'MEMBER_ACTIVE', " +
+                "JMLM.ENTERED_DATE , " +
+                "JVM.VACATION_ID , " +
+                "JVM.LEAVE_DEDUCT , " +
+                "JVM.VACATION_STATUS , " +
+                "JVM.VACATION_TYPE , " +
+                "JVD.START_DATE_TIME , " +
+                "JVD.END_DATE_TIME , " +
+                "JOM.COMPANY_ID, " +
+                "JOM.DEPARTMENT_ID , " +
+                "JOM.IS_ACTIVE AS 'ORG_ACTIVE' FROM JXX_MEMBER_LEAVE_MASTER JMLM " +
+                " JOIN JXX_ORGANIZATION_MASTER JOM " +
+                " ON JMLM.COMPANY_ID = JOM.COMPANY_ID AND JMLM.DEPARTMENT_ID = JOM.DEPARTMENT_ID " +
+                " JOIN JXX_VACATION_MASTER JVM " +
+                " ON JMLM.MEMBER_ID = JVM.REQUESTER_ID " +
+                " JOIN JXX_VACATION_DURATION JVD " +
+                " ON JVD.VACATION_ID = JVM.VACATION_ID " +
+                " WHERE JVD.END_DATE_TIME = ? ;";
+
+        JobContext context = JobSynchronizationManager.getContext();
+
+        String executeDateTime = String.valueOf(context.getJobParameters().get(JOB_PARAM_EXECUTE_DATE_TIME.keyName()));
+        String endDateTime = LocalDateTimeConverter.adjustDateTime(executeDateTime, EXECUTE_DATE_TIME_ADJUST_VALUE);
+
+        return new JdbcCursorItemReaderBuilder<LeaveItem>()
+                .name("leaveItemReader")
+                .dataSource(dataSource)
+                .fetchSize(3)
+                .sql(sql)
+                .rowMapper(new LeaveItemRowMapper())
+                .preparedStatementSetter(ps -> ps.setString(1, endDateTime))
+                .build();
+    }
+}

--- a/vacation-batch/src/main/java/com/jxx/vacation/batch/job/leave/reader/LeaveItemReaderFactory.java
+++ b/vacation-batch/src/main/java/com/jxx/vacation/batch/job/leave/reader/LeaveItemReaderFactory.java
@@ -36,7 +36,8 @@ public class LeaveItemReaderFactory {
                 "JVD.END_DATE_TIME , " +
                 "JOM.COMPANY_ID, " +
                 "JOM.DEPARTMENT_ID , " +
-                "JOM.IS_ACTIVE AS 'ORG_ACTIVE' FROM JXX_MEMBER_LEAVE_MASTER JMLM " +
+                "JOM.IS_ACTIVE AS 'ORG_ACTIVE'," +
+                "JVD.LAST_DURATION FROM JXX_MEMBER_LEAVE_MASTER JMLM " +
                 " JOIN JXX_ORGANIZATION_MASTER JOM " +
                 " ON JMLM.COMPANY_ID = JOM.COMPANY_ID AND JMLM.DEPARTMENT_ID = JOM.DEPARTMENT_ID " +
                 " JOIN JXX_VACATION_MASTER JVM " +

--- a/vacation-batch/src/main/java/com/jxx/vacation/batch/job/leave/reader/LeaveItemRowMapper.java
+++ b/vacation-batch/src/main/java/com/jxx/vacation/batch/job/leave/reader/LeaveItemRowMapper.java
@@ -41,6 +41,7 @@ public class LeaveItemRowMapper implements RowMapper<LeaveItem> {
         String companyId = rs.getString("COMPANY_ID");
         String departmentId = rs.getString("DEPARTMENT_ID");
         boolean orgActive = rs.getBoolean("ORG_ACTIVE");
+        String lastDuration = rs.getString("LAST_DURATION");
 
         return new LeaveItem(memberPk,
                 createTime,
@@ -59,6 +60,7 @@ public class LeaveItemRowMapper implements RowMapper<LeaveItem> {
                 endDateTime,
                 companyId,
                 departmentId,
-                orgActive);
+                orgActive,
+                lastDuration);
     }
 }

--- a/vacation-batch/src/main/java/com/jxx/vacation/batch/job/vacation/status/config/VacationStartEventJobConfiguration.java
+++ b/vacation-batch/src/main/java/com/jxx/vacation/batch/job/vacation/status/config/VacationStartEventJobConfiguration.java
@@ -71,8 +71,19 @@ public class VacationStartEventJobConfiguration {
         return new JdbcCursorItemReaderBuilder<VacationItem>()
                 .fetchSize(100)
                 .dataSource(dataSource)
-                .sql("SELECT * FROM JXX_VACATION_MASTER JVM " +
-                    "   WHERE START_DATE_TIME = ? ")
+                .sql("SELECT " +
+                        "JVM.VACATION_ID , " +
+                        "JVM.LEAVE_DEDUCT , " +
+                        "JVM.CREATE_TIME , " +
+                        "JVM.REQUESTER_ID , " +
+                        "JVD.START_DATE_TIME , " +
+                        "JVD.END_DATE_TIME, " +
+                        "JVM.VACATION_TYPE , " +
+                        "JVM.COMPANY_ID , " +
+                        "JVM.VACATION_STATUS " +
+                        "FROM JXX_VACATION_MASTER JVM " +
+                        "JOIN JXX_VACATION_DURATION JVD ON JVM.VACATION_ID  = JVD.VACATION_ID " +
+                        "WHERE START_DATE_TIME = ?")
                 .rowMapper(new VacationItemRowMapper())
                 .name("vacationItemJdbcReader")
                 .preparedStatementSetter(preparedStatement -> preparedStatement.setString(1, processDate))
@@ -120,8 +131,6 @@ public class VacationStartEventJobConfiguration {
                 "TASK_TYPE, " +
                 "LEAVE_DEDUCT, " +
                 "REQUESTER_ID, " +
-                "END_DATE_TIME, " +
-                "START_DATE_TIME, " +
                 "VACATION_TYPE, " +
                 "VACATION_ID, " +
                 "VACATION_STATUS) VALUES " +
@@ -132,8 +141,6 @@ public class VacationStartEventJobConfiguration {
                 "'U'," +
                 ":leaveDeduct," +
                 ":requesterId," +
-                ":endDateTime," +
-                ":startDateTime," +
                 ":vacationType," +
                 ":vacationId," +
                 ":vacationStatus)";

--- a/vacation-batch/src/main/resources/api/batch.http
+++ b/vacation-batch/src/main/resources/api/batch.http
@@ -5,8 +5,8 @@ Content-Type: application/json
 {
   "properties": {
     "jobName": "vacation.start.job",
-    "run.id": "ADMIN20240412-002",
-    "processDate": "2024-04-12 00:00:00"
+    "run.id": "ADMIN20240416-001",
+    "processDate": "2024-03-26 00:00:00"
   }
 }
 
@@ -22,15 +22,15 @@ Content-Type: application/json
 }
 
 
-### 휴가 종료일에 맞춰 휴가 상태 조정 및 잔여 연차 차감
+### 휴가 종료일에 맞춰 휴가 상태 조정 및 잔여 연차 차감 예를 들어, 16일까지 휴가라면 executeDateTime = 2024-04-17 00:00:00 넣어서 처리
 POST http://localhost:8070/batch/job/run
 Content-Type: application/json
 
 {
   "properties": {
     "jobName": "vacation.end.job",
-    "run.id": "ADMIN20240411-01",
-    "executeDateTime": "2024-04-12 00:00:00"
+    "run.id": "ADMIN20240416-04",
+    "executeDateTime": "2024-04-20 00:00:00"
   }
 }
 

--- a/vacation-batch/src/test/java/com/jxx/vacation/batch/job/leave/config/VacationEndEventJobConfigurationTest.java
+++ b/vacation-batch/src/test/java/com/jxx/vacation/batch/job/leave/config/VacationEndEventJobConfigurationTest.java
@@ -1,0 +1,96 @@
+package com.jxx.vacation.batch.job.leave.config;
+
+
+import com.jxx.vacation.core.vacation.domain.entity.*;
+import com.jxx.vacation.core.vacation.infra.MemberLeaveRepository;
+import com.jxx.vacation.core.vacation.infra.OrganizationRepository;
+import com.jxx.vacation.core.vacation.infra.VacationRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.batch.core.*;
+import org.springframework.batch.test.JobLauncherTestUtils;
+import org.springframework.batch.test.context.SpringBatchTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import static com.jxx.vacation.batch.job.parameters.JxxJobParameter.JOB_PARAM_EXECUTE_DATE_TIME;
+import static org.assertj.core.api.Assertions.*;
+
+/**
+ * 테스트 컨테이너 써야될 듯... h2 - mysql SQL 문법 호환 안되는 부분 존재
+ */
+
+@Slf4j
+@SpringBootTest
+@SpringBatchTest
+class VacationEndEventJobConfigurationTest {
+
+    @Autowired
+    private JobLauncherTestUtils jobLauncherTestUtils;
+
+    @Autowired
+    private ApplicationContext context;
+
+    @Autowired
+    private MemberLeaveRepository memberLeaveRepository;
+    @Autowired
+    private OrganizationRepository organizationRepository;
+    @Autowired
+    private VacationRepository vacationRepository;
+
+    @BeforeEach
+    void init() {
+        Organization organization = new Organization(
+                "O0001",
+                "TJX",
+                "T0001",
+                "테스트부서",
+                "TOP",
+                "");
+
+        MemberLeave memberLeave = MemberLeave.builder()
+                .memberId("T0001")
+                .name("나재헌")
+                .experienceYears(1)
+                .enteredDate(LocalDate.of(2023, 8, 16))
+                .leave(new Leave(15F, 15F))
+                .organization(organization)
+                .build();
+
+        Vacation vacation = Vacation.builder()
+                .leaveDeduct(LeaveDeduct.DEDUCT)
+                .vacationDuration(new VacationDuration(VacationType.MORE_DAY, LocalDateTime.now(),LocalDateTime.now()))
+                .vacationStatus(VacationStatus.CREATE)
+                .requesterId(memberLeave.getMemberId())
+                .companyId(organization.getCompanyId())
+                .build();
+
+        organizationRepository.save(organization);
+        MemberLeave savedMemberLeave = memberLeaveRepository.save(memberLeave);
+        vacationRepository.save(vacation);
+
+        log.info("=========================================");
+        log.info("savedMemberLeave {}", savedMemberLeave);
+        log.info("=========================================");
+    }
+
+    @Test
+    public void testJob() throws Exception {
+        Job job = context.getBean("vacation.end.job", Job.class);
+        jobLauncherTestUtils.setJob(job);
+
+        JobParametersBuilder parametersBuilder = new JobParametersBuilder();
+        parametersBuilder.addJobParameter(JOB_PARAM_EXECUTE_DATE_TIME.keyName(), new JobParameter<>("2024-04-12 00:00:00", String.class));
+        JobParameters jobParameters = parametersBuilder.toJobParameters();
+
+        JobExecution jobExecution = jobLauncherTestUtils.launchJob(jobParameters);
+
+        assertThat("COMPLETED").isEqualTo(jobExecution.getExitStatus().getExitCode());
+    }
+}

--- a/vacation-batch/src/test/java/com/jxx/vacation/batch/job/leave/config/VacationEndEventJobConfigurationTest.java
+++ b/vacation-batch/src/test/java/com/jxx/vacation/batch/job/leave/config/VacationEndEventJobConfigurationTest.java
@@ -1,6 +1,8 @@
 package com.jxx.vacation.batch.job.leave.config;
 
 
+import com.jxx.vacation.batch.job.leave.item.LeaveItem;
+import com.jxx.vacation.batch.job.leave.reader.LeaveItemReaderFactory;
 import com.jxx.vacation.core.vacation.domain.entity.*;
 import com.jxx.vacation.core.vacation.infra.MemberLeaveRepository;
 import com.jxx.vacation.core.vacation.infra.OrganizationRepository;
@@ -10,12 +12,14 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.batch.core.*;
+import org.springframework.batch.item.database.JdbcCursorItemReader;
 import org.springframework.batch.test.JobLauncherTestUtils;
 import org.springframework.batch.test.context.SpringBatchTest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationContext;
 
+import javax.sql.DataSource;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
@@ -65,7 +69,7 @@ class VacationEndEventJobConfigurationTest {
 
         Vacation vacation = Vacation.builder()
                 .leaveDeduct(LeaveDeduct.DEDUCT)
-                .vacationDuration(new VacationDuration(VacationType.MORE_DAY, LocalDateTime.now(),LocalDateTime.now()))
+                .vacationType(VacationType.MORE_DAY)
                 .vacationStatus(VacationStatus.CREATE)
                 .requesterId(memberLeave.getMemberId())
                 .companyId(organization.getCompanyId())
@@ -81,7 +85,7 @@ class VacationEndEventJobConfigurationTest {
     }
 
     @Test
-    public void testJob() throws Exception {
+    void testJob() throws Exception {
         Job job = context.getBean("vacation.end.job", Job.class);
         jobLauncherTestUtils.setJob(job);
 

--- a/vacation-batch/src/test/java/com/jxx/vacation/batch/job/leave/processor/LeaveItemValidateProcessorTest.java
+++ b/vacation-batch/src/test/java/com/jxx/vacation/batch/job/leave/processor/LeaveItemValidateProcessorTest.java
@@ -58,8 +58,11 @@ class LeaveItemValidateProcessorTest {
     void leave_item_validate_success() throws Exception {
         //given
         String vacationStatus = "ONGOING";
-        LocalDateTime vacationStartDateTime = LocalDateTime.of(2025, 12, 12, 0, 0,0);
-        LocalDateTime vacationEndDateTime = LocalDateTime.of(2025, 12, 13, 0,0,0);
+
+        //목요일
+        LocalDateTime vacationStartDateTime = LocalDateTime.of(2025, 12, 11, 0, 0,0);
+        //금요일
+        LocalDateTime vacationEndDateTime = LocalDateTime.of(2025, 12, 12, 0,0,0);
         LeaveItem leaveItem = new LeaveItem(
                 "U00013",
                 LocalDateTime.now(),

--- a/vacation-batch/src/test/java/com/jxx/vacation/batch/job/leave/processor/LeaveItemValidateProcessorTest.java
+++ b/vacation-batch/src/test/java/com/jxx/vacation/batch/job/leave/processor/LeaveItemValidateProcessorTest.java
@@ -44,7 +44,8 @@ class LeaveItemValidateProcessorTest {
                 vacationEndDateTime,
                 "JXX",
                 "departId",
-                true);
+                true,
+                "Y");
         //when
         LeaveItem processedItem = leaveItemValidateProcessor.process(leaveItem);
         //then
@@ -81,7 +82,8 @@ class LeaveItemValidateProcessorTest {
                 vacationEndDateTime,
                 "JXX",
                 "departId",
-                true);
+                true,
+                "Y");
         //when
         LeaveItem processedItem = leaveItemValidateProcessor.process(leaveItem);
         //then

--- a/vacation-core/src/main/java/com/jxx/vacation/core/vacation/domain/RequestVacationDuration.java
+++ b/vacation-core/src/main/java/com/jxx/vacation/core/vacation/domain/RequestVacationDuration.java
@@ -1,0 +1,9 @@
+package com.jxx.vacation.core.vacation.domain;
+
+import java.time.LocalDateTime;
+
+public record RequestVacationDuration(
+        LocalDateTime startDateTime,
+        LocalDateTime endDateTime
+) {
+}

--- a/vacation-core/src/main/java/com/jxx/vacation/core/vacation/domain/VacationDurationDto.java
+++ b/vacation-core/src/main/java/com/jxx/vacation/core/vacation/domain/VacationDurationDto.java
@@ -1,0 +1,11 @@
+package com.jxx.vacation.core.vacation.domain;
+
+import java.time.LocalDateTime;
+
+public record VacationDurationDto(
+        Long vacationDurationId,
+        LocalDateTime startDateTime,
+        LocalDateTime endDateTime,
+        Float useLeaveValue
+) {
+}

--- a/vacation-core/src/main/java/com/jxx/vacation/core/vacation/domain/entity/Vacation.java
+++ b/vacation-core/src/main/java/com/jxx/vacation/core/vacation/domain/entity/Vacation.java
@@ -78,14 +78,6 @@ public class Vacation {
         this.createTime = LocalDateTime.now();
     }
 
-    protected Vacation(String requesterId, String companyId, LeaveDeduct leaveDeduct, VacationStatus vacationStatus) {
-        this.requesterId = requesterId;
-        this.companyId = companyId;
-        this.leaveDeduct = leaveDeduct;
-        this.vacationStatus = vacationStatus;
-        this.createTime = LocalDateTime.now();
-    }
-
     public boolean isDeductVacationType() {
         return vacationType.deductType();
     }

--- a/vacation-core/src/main/java/com/jxx/vacation/core/vacation/domain/entity/Vacation.java
+++ b/vacation-core/src/main/java/com/jxx/vacation/core/vacation/domain/entity/Vacation.java
@@ -106,10 +106,6 @@ public class Vacation {
         return vacationType.equals(VacationType.MORE_DAY);
     }
 
-    public void addAllVacationDuration(List<VacationDuration> vacationDuration) {
-        vacationDurations.addAll(vacationDuration);
-    }
-
     public List<VacationDurationDto> receiveVacationDurationDto() {
         return vacationDurations.stream()
                 .map(vd -> new VacationDurationDto(vd.getId(),vd.getStartDateTime(), vd.getEndDateTime(), vd.getUseLeaveValue()))

--- a/vacation-core/src/main/java/com/jxx/vacation/core/vacation/domain/entity/VacationDuration.java
+++ b/vacation-core/src/main/java/com/jxx/vacation/core/vacation/domain/entity/VacationDuration.java
@@ -1,6 +1,7 @@
 package com.jxx.vacation.core.vacation.domain.entity;
 
 import com.jxx.vacation.core.vacation.domain.exeception.VacationClientException;
+import com.jxx.vacation.core.vacation.domain.service.VacationCalculator;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -48,10 +49,10 @@ public class VacationDuration {
         vacation.addVacationDuration(this);
     }
 
-    public VacationDuration(LocalDateTime startDateTime, LocalDateTime endDateTime, Float useLeaveValue) {
+    public VacationDuration(LocalDateTime startDateTime, LocalDateTime endDateTime, LeaveDeduct leaveDeduct) {
         this.startDateTime = startDateTime;
         this.endDateTime = endDateTime;
-        this.useLeaveValue = useLeaveValue;
+        this.useLeaveValue = VacationCalculator.calculateUseLeaveValue(leaveDeduct, startDateTime, endDateTime);
     }
 
     public float calculateDate() {

--- a/vacation-core/src/main/java/com/jxx/vacation/core/vacation/domain/entity/VacationDuration.java
+++ b/vacation-core/src/main/java/com/jxx/vacation/core/vacation/domain/entity/VacationDuration.java
@@ -39,6 +39,10 @@ public class VacationDuration {
     @Comment(value = "사용 연차")
     private Float useLeaveValue;
 
+    @Column(name = "LAST_DURATION", nullable = false)
+    @Comment(value = "마지막 기간 여부(N:마지막X/Y:마지막O)")
+    private String lastDuration;
+
     @ManyToOne
     @JoinColumn(name = "VACATION_ID", referencedColumnName = "VACATION_ID",
             foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
@@ -49,10 +53,26 @@ public class VacationDuration {
         vacation.addVacationDuration(this);
     }
 
+    public void changeLastDuration() {
+        this.lastDuration = "Y";
+    }
+
+
+
+    /**
+     * 휴가 종료일이 과거일수록 인덱스를 앞으로 위치시키기 위함
+     * 예를 들어 요소 A(종료일 2024-04-15),요소 B(종료일 2024-04-18),요소 C(종료일 2024-04-17)
+     * 이면 A,C,B 순으로 정렬된다.
+     */
+    public int sortByEndDateTime(VacationDuration vacationDuration) {
+        return this.endDateTime.isAfter(vacationDuration.getEndDateTime()) ? 1 : -1;
+    }
+
     public VacationDuration(LocalDateTime startDateTime, LocalDateTime endDateTime, LeaveDeduct leaveDeduct) {
         this.startDateTime = startDateTime;
         this.endDateTime = endDateTime;
         this.useLeaveValue = VacationCalculator.calculateUseLeaveValue(leaveDeduct, startDateTime, endDateTime);
+        this.lastDuration = "N";
     }
 
     public float calculateDate() {

--- a/vacation-core/src/main/java/com/jxx/vacation/core/vacation/domain/entity/VacationDuration.java
+++ b/vacation-core/src/main/java/com/jxx/vacation/core/vacation/domain/entity/VacationDuration.java
@@ -1,10 +1,7 @@
 package com.jxx.vacation.core.vacation.domain.entity;
 
 import com.jxx.vacation.core.vacation.domain.exeception.VacationClientException;
-import jakarta.persistence.Column;
-import jakarta.persistence.Embeddable;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
+import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Comment;
@@ -16,16 +13,20 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Getter
-@Embeddable
+@Entity
 @NoArgsConstructor
+@Table(name = "JXX_VACATION_DURATION", indexes = {
+        @Index(name = "IDX_START_DATE_TIME", columnList = "START_DATE_TIME"),
+        @Index(name = "IDX_END_DATE_TIME", columnList = "END_DATE_TIME")
+})
 public class VacationDuration {
 
     private static long DATE_ADJUSTMENTS_VALUE = 1l;
 
-    @Column(name = "VACATION_TYPE", nullable = false)
-    @Comment(value = "연차 유형")
-    @Enumerated(value = EnumType.STRING)
-    private VacationType vacationType;
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "VACATION_DURATION_ID")
+    @Comment("휴가 기간 ID")
+    private Long id;
 
     @Column(name = "START_DATE_TIME", nullable = false)
     @Comment(value = "연차 시작 시간")
@@ -33,11 +34,24 @@ public class VacationDuration {
     @Column(name = "END_DATE_TIME", nullable = false)
     @Comment(value = "연차 종료 시간")
     private LocalDateTime endDateTime;
+    @Column(name = "USE_LEAVE_VALUE", nullable = false)
+    @Comment(value = "사용 연차")
+    private Float useLeaveValue;
 
-    public VacationDuration(VacationType vacationType, LocalDateTime startDateTime, LocalDateTime endDateTime) {
-        this.vacationType = vacationType;
+    @ManyToOne
+    @JoinColumn(name = "VACATION_ID", referencedColumnName = "VACATION_ID",
+            foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    private Vacation vacation;
+
+    public void mappingVacation(Vacation mappingVacation) {
+        vacation = mappingVacation;
+        vacation.addVacationDuration(this);
+    }
+
+    public VacationDuration(LocalDateTime startDateTime, LocalDateTime endDateTime, Float useLeaveValue) {
         this.startDateTime = startDateTime;
         this.endDateTime = endDateTime;
+        this.useLeaveValue = useLeaveValue;
     }
 
     public float calculateDate() {
@@ -68,9 +82,6 @@ public class VacationDuration {
         return dates;
     }
 
-    public boolean isDeductVacationType() {
-        return vacationType.deductType();
-    }
 
     // 휴일, 공휴일...
     public long countNotWorkingDate() {

--- a/vacation-core/src/main/java/com/jxx/vacation/core/vacation/domain/entity/VacationHistory.java
+++ b/vacation-core/src/main/java/com/jxx/vacation/core/vacation/domain/entity/VacationHistory.java
@@ -43,6 +43,10 @@ public class VacationHistory {
     @Comment(value = "휴가 신청 상태")
     @Enumerated(value = EnumType.STRING)
     private VacationStatus vacationStatus;
+    @Column(name = "VACATION_TYPE", nullable = false)
+    @Comment(value = "연차 유형")
+    @Enumerated(value = EnumType.STRING)
+    private VacationType vacationType;
 
     @Column(name = "CREATE_TIME", nullable = false)
     @Comment(value = "레코드 생성 시간")
@@ -58,6 +62,7 @@ public class VacationHistory {
         this.leaveDeduct = vacation.getLeaveDeduct();
         this.vacationStatus = vacation.getVacationStatus();
         this.createTime = vacation.getCreateTime();
+        this.vacationType = vacation.getVacationType();
         this.history = history;
     }
 }

--- a/vacation-core/src/main/java/com/jxx/vacation/core/vacation/domain/entity/VacationHistory.java
+++ b/vacation-core/src/main/java/com/jxx/vacation/core/vacation/domain/entity/VacationHistory.java
@@ -35,8 +35,6 @@ public class VacationHistory {
     @Comment(value = "회사 식별자")
     private String companyId;
 
-    @Embedded
-    private VacationDuration vacationDuration;
     @Column(name = "LEAVE_DEDUCT", nullable = false)
     @Comment(value = "연차 차감 여부")
     @Enumerated(EnumType.STRING)
@@ -57,7 +55,6 @@ public class VacationHistory {
         this.vacationId = vacation.getId();
         this.requesterId = vacation.getRequesterId();
         this.companyId = vacation.getCompanyId();
-        this.vacationDuration = vacation.getVacationDuration();
         this.leaveDeduct = vacation.getLeaveDeduct();
         this.vacationStatus = vacation.getVacationStatus();
         this.createTime = vacation.getCreateTime();

--- a/vacation-core/src/main/java/com/jxx/vacation/core/vacation/domain/entity/VacationManager.java
+++ b/vacation-core/src/main/java/com/jxx/vacation/core/vacation/domain/entity/VacationManager.java
@@ -17,11 +17,8 @@ import static com.jxx.vacation.core.vacation.domain.entity.VacationStatus.*;
 @Slf4j
 @Getter
 public class VacationManager {
-    private Float vacationDate;
     private final MemberLeave memberLeave;
     private final Vacation vacation; // 영속화가 보장되어 있지 않으니 주의
-    private List<VacationDuration> vacationDurations;
-
 
     /**
      * 해당 메서드로 생성 시 Vacation 영속화된 상태가 아니니 주의
@@ -53,11 +50,8 @@ public class VacationManager {
 
     // update
     private VacationManager(Vacation vacation, MemberLeave memberLeave) {
-        this.vacationDate = VacationCalculator.getVacationDuration(vacation);
         this.memberLeave = memberLeave;
         this.vacation = vacation;
-        this.vacationDurations = vacation.getVacationDurations();
-
         validateMemberActive();
     }
 
@@ -85,11 +79,11 @@ public class VacationManager {
         return true;
     }
 
-    public void validateRemainingLeaveIsBiggerThanConfirmingVacationsAnd(List<Vacation> requestVacations) {
+    public void validateRemainingLeaveIsBiggerThanConfirmingVacationsAnd(List<Vacation> alreadyRequestVacations) {
         Float remainingLeave = memberLeave.receiveRemainingLeave();
 
         // 현재 REQUEST, APPROVED 상태의 휴가 신청일 총 합
-        List<Float> vacationDays = requestVacations.stream()
+        List<Float> vacationDays = alreadyRequestVacations.stream()
                 .filter(vacation -> CONFIRMING_GROUP.contains(vacation.getVacationStatus()))
                 .map(vacation -> vacation.useLeaveValueSum())
                 .toList();
@@ -168,12 +162,6 @@ public class VacationManager {
         return raise(ConfirmStatus.valueOf(confirmStatus));
     }
 
-    public float receiveVacationDate() {
-        if (Objects.isNull(vacationDate)) {
-            throw new IllegalStateException("");
-        }
-        return vacationDate;
-    }
     // 휴가 취소 (결재 문서를 취소)
     public Vacation cancel() {
         if (!CANCEL_POSSIBLE_GROUP.contains(vacation.getVacationStatus())) {

--- a/vacation-core/src/main/java/com/jxx/vacation/core/vacation/domain/entity/VacationManager.java
+++ b/vacation-core/src/main/java/com/jxx/vacation/core/vacation/domain/entity/VacationManager.java
@@ -4,39 +4,51 @@ import com.jxx.vacation.core.message.body.vendor.confirm.ConfirmStatus;
 import com.jxx.vacation.core.vacation.domain.exeception.InactiveException;
 import com.jxx.vacation.core.vacation.domain.exeception.VacationClientException;
 import com.jxx.vacation.core.vacation.domain.service.VacationCalculator;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
 import static com.jxx.vacation.core.vacation.domain.entity.VacationStatus.*;
 
 @Slf4j
+@Getter
 public class VacationManager {
-    private final float vacationDate;
+    private Float vacationDate;
     private final MemberLeave memberLeave;
     private final Vacation vacation; // 영속화가 보장되어 있지 않으니 주의
+    private List<VacationDuration> vacationDurations;
 
 
     /**
      * 해당 메서드로 생성 시 Vacation 영속화된 상태가 아니니 주의
      */
-    public static VacationManager createVacation(VacationDuration vacationDuration, MemberLeave memberLeave) {
-        return new VacationManager(vacationDuration, memberLeave);
+    public static VacationManager create(MemberLeave memberLeave, VacationType vacationType, LeaveDeduct leaveDeduct) {
+        return new VacationManager(memberLeave, vacationType, leaveDeduct);
     }
+    private VacationManager(MemberLeave memberLeave, VacationType vacationType, LeaveDeduct leaveDeduct) {
+        this.memberLeave = memberLeave;
+        this.vacation = createVacation(vacationType, leaveDeduct);
+        validateMemberActive();
+    }
+
+    // Vacation Duration
+    public Vacation createVacation(VacationType vacationType, LeaveDeduct leaveDeduct) {
+        return Vacation.builder()
+                .vacationType(vacationType)
+                .vacationStatus(CREATE)
+                .leaveDeduct(leaveDeduct)
+                .requesterId(memberLeave.getMemberId())
+                .companyId(memberLeave.receiveCompanyId())
+                .build();
+    }
+
 
     public static VacationManager updateVacation(Vacation vacation, MemberLeave memberLeave) {
         return new VacationManager(vacation, memberLeave);
-    }
-
-    // create
-    private VacationManager(VacationDuration vacationDuration, MemberLeave memberLeave) {
-        this.memberLeave = memberLeave;
-        this.vacation = create(vacationDuration);
-        this.vacationDate = VacationCalculator.getVacationDuration(this.vacation);
-
-        validateMemberActive();
     }
 
     // update
@@ -44,18 +56,19 @@ public class VacationManager {
         this.vacationDate = VacationCalculator.getVacationDuration(vacation);
         this.memberLeave = memberLeave;
         this.vacation = vacation;
+        this.vacationDurations = vacation.getVacationDurations();
 
         validateMemberActive();
     }
 
-    protected Vacation create(VacationDuration vacationDuration) {
-        return decideDeduct(vacationDuration, memberLeave.getMemberId(), memberLeave.receiveCompanyId());
+    protected Vacation create(VacationType vacationType) {
+        return decideDeduct(vacationType, memberLeave.getMemberId(), memberLeave.receiveCompanyId());
     }
 
-    private Vacation decideDeduct(VacationDuration vacationDuration, String requesterId, String companyId) {
-        return vacationDuration.isDeductVacationType() ?
-                Vacation.createDeductVacation(requesterId, companyId, vacationDuration) :
-                Vacation.createNotDeductVacation(requesterId, companyId, vacationDuration);
+    private Vacation decideDeduct(VacationType vacationType, String requesterId, String companyId) {
+        return VacationType.DEDUCT_TYPE.contains(vacationType.getType()) ?
+                Vacation.createDeductVacation(requesterId, companyId, vacationType) :
+                Vacation.createNotDeductVacation(requesterId, companyId, vacationType);
     }
 
     public boolean validateMemberActive() {
@@ -78,7 +91,7 @@ public class VacationManager {
         // 현재 REQUEST, APPROVED 상태의 휴가 신청일 총 합
         List<Float> vacationDays = requestVacations.stream()
                 .filter(vacation -> CONFIRMING_GROUP.contains(vacation.getVacationStatus()))
-                .map(vacation -> vacation.getVacationDuration().calculateDate())
+                .map(vacation -> vacation.useLeaveValueSum())
                 .toList();
 
         Float approvingVacationDate = 0F;
@@ -86,7 +99,7 @@ public class VacationManager {
             approvingVacationDate += vacationDay;
         }
         // 신청한 휴가 일 수
-        float requestVacationDate = vacation.getVacationDuration().calculateDate();
+        Float requestVacationDate = vacation.useLeaveValueSum();
 
         String clientId = memberLeave.getMemberId();
         if (remainingLeave - approvingVacationDate - requestVacationDate < 0) {
@@ -94,16 +107,40 @@ public class VacationManager {
         }
     }
 
+//    public void validateVacationDatesAreDuplicated(List<Vacation> requestVacations) {
+//        List<VacationDuration> confirmingAndOngoingVacationDurations = requestVacations.stream()
+//                .filter(vacation -> CONFIRMING_AND_ONGOING_GROUP.contains(vacation.getVacationStatus()))
+//                .map(vacation -> vacation.getVacationDuration())
+//                .toList();
+//
+//        VacationDuration requestVacationDuration = vacation.getVacationDuration();
+//        List<LocalDateTime> requestVacationDateTimes = requestVacationDuration.receiveVacationDateTimes();
+//
+//        for (VacationDuration vacationDuration : confirmingAndOngoingVacationDurations) {
+//            for (LocalDateTime requestVacationDateTime : requestVacationDateTimes) {
+//                vacationDuration.isAlreadyInVacationDate(requestVacationDateTime);
+//            }
+//        }
+//    }
+
     public void validateVacationDatesAreDuplicated(List<Vacation> requestVacations) {
-        List<VacationDuration> confirmingAndOngoingVacationDurations = requestVacations.stream()
+        List<Vacation> afterConfirmingVacations = requestVacations.stream()
                 .filter(vacation -> CONFIRMING_AND_ONGOING_GROUP.contains(vacation.getVacationStatus()))
-                .map(vacation -> vacation.getVacationDuration())
                 .toList();
 
-        VacationDuration requestVacationDuration = vacation.getVacationDuration();
-        List<LocalDateTime> requestVacationDateTimes = requestVacationDuration.receiveVacationDateTimes();
+        List<VacationDuration> afterConfirmingVacationDurations = new ArrayList<>();
+        for (Vacation afterConfirmingVacation : afterConfirmingVacations) {
+            List<VacationDuration> vd = afterConfirmingVacation.getVacationDurations();
+            afterConfirmingVacationDurations.addAll(vd);
+        }
 
-        for (VacationDuration vacationDuration : confirmingAndOngoingVacationDurations) {
+        List<LocalDateTime> requestVacationDateTimes = new ArrayList<>();
+        List<VacationDuration> requestVacationDurations = vacation.getVacationDurations();
+        for (VacationDuration requestVacationDuration : requestVacationDurations) {
+            requestVacationDateTimes.addAll(requestVacationDuration.receiveVacationDateTimes());
+        }
+
+        for (VacationDuration vacationDuration : afterConfirmingVacationDurations) {
             for (LocalDateTime requestVacationDateTime : requestVacationDateTimes) {
                 vacationDuration.isAlreadyInVacationDate(requestVacationDateTime);
             }
@@ -137,16 +174,6 @@ public class VacationManager {
         }
         return vacationDate;
     }
-
-    public Vacation getVacation() {
-        return this.vacation;
-    }
-
-    public MemberLeave getMemberLeave() {
-        return this.memberLeave;
-    }
-
-
     // 휴가 취소 (결재 문서를 취소)
     public Vacation cancel() {
         if (!CANCEL_POSSIBLE_GROUP.contains(vacation.getVacationStatus())) {
@@ -157,11 +184,11 @@ public class VacationManager {
     }
 
     // 휴가 수정
-    public Vacation update(VacationDuration vacationDuration) {
-        if (!CREATE.equals(vacation.getVacationStatus())) {
-            throw new IllegalArgumentException("수정 불가능>.<");
-        }
-        vacation.updateVacationDuration(vacationDuration);
-        return vacation;
-    }
+//    public Vacation update(VacationDuration vacationDuration) {
+//        if (!CREATE.equals(vacation.getVacationStatus())) {
+//            throw new IllegalArgumentException("수정 불가능>.<");
+//        }
+//        vacation.updateVacationDuration(vacationDuration);
+//        return vacation;
+//    }
 }

--- a/vacation-core/src/main/java/com/jxx/vacation/core/vacation/domain/service/VacationCalculator.java
+++ b/vacation-core/src/main/java/com/jxx/vacation/core/vacation/domain/service/VacationCalculator.java
@@ -3,7 +3,15 @@ package com.jxx.vacation.core.vacation.domain.service;
 import com.jxx.vacation.core.vacation.domain.entity.LeaveDeduct;
 import com.jxx.vacation.core.vacation.domain.entity.Vacation;
 import com.jxx.vacation.core.vacation.domain.entity.VacationDuration;
+import com.jxx.vacation.core.vacation.domain.entity.VacationType;
+import com.jxx.vacation.core.vacation.domain.exeception.VacationClientException;
 import lombok.extern.slf4j.Slf4j;
+
+import java.time.DayOfWeek;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
 
 import static com.jxx.vacation.core.vacation.domain.entity.VacationType.*;
 
@@ -11,10 +19,12 @@ import static com.jxx.vacation.core.vacation.domain.entity.VacationType.*;
 public class VacationCalculator {
 
     private final static float HALF_VACATION_DEDUCTED_VALE = 0.5F;
+    private static long DATE_ADJUSTMENTS_VALUE = 1l;
 
-    public static float getVacationDuration(Vacation vacation) {
+
+    public static Float getVacationDuration(Vacation vacation) {
         if (LeaveDeduct.isLeaveDeductVacation(vacation.getLeaveDeduct()) && isMoreOneDay(vacation)) {
-            return vacation.getVacationDuration().calculateDate();
+            return 1F;
         }
 
         if (LeaveDeduct.isLeaveDeductVacation(vacation.getLeaveDeduct()) && isHalfDay(vacation)) {
@@ -28,35 +38,35 @@ public class VacationCalculator {
         return 0F;
     }
 
-    public static float getVacationDuration(VacationDuration vacationDuration, LeaveDeduct leaveDeduct) {
+    public static float getVacationDuration(VacationType vacationType, VacationDuration vacationDuration, LeaveDeduct leaveDeduct) {
         // 하루 이상 연차
-        if (!LeaveDeduct.NOT_DEDUCT.equals(leaveDeduct) && MORE_DAY.equals(vacationDuration.getVacationType())) {
+        if (!LeaveDeduct.NOT_DEDUCT.equals(leaveDeduct) && MORE_DAY.equals(vacationType)) {
             return vacationDuration.calculateDate();
         }
 
         // 반차
-        if (!LeaveDeduct.NOT_DEDUCT.equals(leaveDeduct) && (HALF_VACATION_TYPE.contains(vacationDuration.getVacationType()))) {
+        if (!LeaveDeduct.NOT_DEDUCT.equals(leaveDeduct) && (HALF_VACATION_TYPE.contains(vacationType))) {
             return HALF_VACATION_DEDUCTED_VALE;
         }
 
         return 0F;
     }
 
-    public float getVacationDays(Vacation vacation) {
-        if (LeaveDeduct.isLeaveDeductVacation(vacation.getLeaveDeduct()) && isMoreOneDay(vacation)) {
-            return vacation.getVacationDuration().calculateDate();
-        }
-
-        if (LeaveDeduct.isLeaveDeductVacation(vacation.getLeaveDeduct()) && isHalfDay(vacation)) {
-            return HALF_VACATION_DEDUCTED_VALE;
-        }
-
-        if (!LeaveDeduct.isLeaveDeductVacation(vacation.getLeaveDeduct())) {
-            log.warn("차감 연차가 아닙니다. 차감을 하지 않습니다.");
-        }
-
-        return 0F;
-    }
+//    public float getVacationDays(Vacation vacation) {
+//        if (LeaveDeduct.isLeaveDeductVacation(vacation.getLeaveDeduct()) && isMoreOneDay(vacation)) {
+//            return vacation.getVacationDuration().calculateDate();
+//        }
+//
+//        if (LeaveDeduct.isLeaveDeductVacation(vacation.getLeaveDeduct()) && isHalfDay(vacation)) {
+//            return HALF_VACATION_DEDUCTED_VALE;
+//        }
+//
+//        if (!LeaveDeduct.isLeaveDeductVacation(vacation.getLeaveDeduct())) {
+//            log.warn("차감 연차가 아닙니다. 차감을 하지 않습니다.");
+//        }
+//
+//        return 0F;
+//    }
 
     private static boolean isMoreOneDay(Vacation vacation) {
         return MORE_DAY.equals(vacation.vacationType());
@@ -64,5 +74,39 @@ public class VacationCalculator {
 
     private static boolean isHalfDay(Vacation vacation) {
         return HALF_MORNING.equals(vacation.vacationType()) || HALF_AFTERNOON.equals(vacation.vacationType());
+    }
+
+    public static float calculateUseLeaveValue(LeaveDeduct leaveDeduct, LocalDateTime startDateTime, LocalDateTime endDateTime) {
+        long vacationDateCount = 0;
+        long notWorkingDateCount = 0;
+        if (LeaveDeduct.isLeaveDeductVacation(leaveDeduct)) {
+            vacationDateCount = ChronoUnit.DAYS.between(startDateTime, endDateTime) + DATE_ADJUSTMENTS_VALUE;
+            notWorkingDateCount = countNotWorkingDate(startDateTime, endDateTime);
+        }
+
+        if (vacationDateCount - notWorkingDateCount < 0) {
+            throw new VacationClientException("잘못된 접근입니다. 휴가일 수 음수");
+        }
+
+        return vacationDateCount - notWorkingDateCount;
+    }
+
+    private static long countNotWorkingDate(LocalDateTime startDateTime, LocalDateTime endDateTime) {
+        List<LocalDateTime> vacationDateTimes = receiveVacationDateTimes(startDateTime, endDateTime);
+        return vacationDateTimes.stream()
+                .filter(vacationDateTime -> vacationDateTime.getDayOfWeek().equals(DayOfWeek.SATURDAY) || vacationDateTime.getDayOfWeek().equals(DayOfWeek.SUNDAY))
+                .count();
+    }
+
+    private static List<LocalDateTime> receiveVacationDateTimes(LocalDateTime startDateTime, LocalDateTime endDateTime) {
+        List<LocalDateTime> dates = new ArrayList<>();
+        LocalDateTime current = startDateTime;
+
+        while (!current.isAfter(endDateTime)) {
+            dates.add(current);
+            current = current.plusDays(1);
+        }
+
+        return dates;
     }
 }

--- a/vacation-core/src/main/java/com/jxx/vacation/core/vacation/infra/VacationDurationRepository.java
+++ b/vacation-core/src/main/java/com/jxx/vacation/core/vacation/infra/VacationDurationRepository.java
@@ -1,0 +1,7 @@
+package com.jxx.vacation.core.vacation.infra;
+
+import com.jxx.vacation.core.vacation.domain.entity.VacationDuration;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface VacationDurationRepository extends JpaRepository<VacationDuration, Long> {
+}

--- a/vacation-core/src/main/java/com/jxx/vacation/core/vacation/infra/VacationRepository.java
+++ b/vacation-core/src/main/java/com/jxx/vacation/core/vacation/infra/VacationRepository.java
@@ -21,20 +21,20 @@ public interface VacationRepository extends JpaRepository<Vacation, Long> {
      * 	WHERE COMPANY_ID = 'SPY' AND DEPARTMENT_ID = 'SPY01001');
      */
 
-    @Query("select new com.jxx.vacation.core.vacation.projection.DepartmentVacationProjection" +
-            "(v.id, " +
-            "v.requesterId, " +
-            "m.name, " +
-            "m.organization.companyName, " +
-            "m.organization.companyId, " +
-            "m.organization.departmentName, " +
-            "m.organization.departmentId, " +
-            "v.vacationDuration.startDateTime, " +
-            "v.vacationDuration.endDateTime, " +
-            "v.vacationDuration.vacationType, " +
-            "v.vacationStatus) from Vacation v inner join MemberLeave m on v.requesterId = m.memberId " +
-            "where v.requesterId in (select m2.memberId from MemberLeave m2 " +
-            "where m2.organization.companyId =:companyId " +
-            "and m2.organization.departmentId =:departmentId and m2.isActive = true )")
-    List<DepartmentVacationProjection> findDepartmentVacation(@Param("companyId") String companyId, @Param("departmentId") String departmentId);
+//    @Query("select new com.jxx.vacation.core.vacation.projection.DepartmentVacationProjection" +
+//            "(v.id, " +
+//            "v.requesterId, " +
+//            "m.name, " +
+//            "m.organization.companyName, " +
+//            "m.organization.companyId, " +
+//            "m.organization.departmentName, " +
+//            "m.organization.departmentId, " +
+//            "v.vacationDuration.startDateTime, " +
+//            "v.vacationDuration.endDateTime, " +
+//            "v.vacationType, " +
+//            "v.vacationStatus) from Vacation v inner join MemberLeave m on v.requesterId = m.memberId " +
+//            "where v.requesterId in (select m2.memberId from MemberLeave m2 " +
+//            "where m2.organization.companyId =:companyId " +
+//            "and m2.organization.departmentId =:departmentId and m2.isActive = true )")
+//    List<DepartmentVacationProjection> findDepartmentVacation(@Param("companyId") String companyId, @Param("departmentId") String departmentId);
 }

--- a/vacation-core/src/test/java/com/jxx/vacation/core/VacationCoreApplicationTests.java
+++ b/vacation-core/src/test/java/com/jxx/vacation/core/VacationCoreApplicationTests.java
@@ -6,8 +6,4 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest
 class VacationCoreApplicationTests {
 
-    @Test
-    void contextLoads() {
-    }
-
 }

--- a/vacation-core/src/test/java/com/jxx/vacation/core/vacation/domain/entity/VacationDurationTest.java
+++ b/vacation-core/src/test/java/com/jxx/vacation/core/vacation/domain/entity/VacationDurationTest.java
@@ -16,17 +16,17 @@ class VacationDurationTest {
     @Test
     void calculate() {
         LocalDateTime today = LocalDateTime.now();
-        VacationDuration vd1 = new VacationDuration(VacationType.MORE_DAY, today, today);
+        VacationDuration vd1 = new VacationDuration(today, today, LeaveDeduct.DEDUCT);
         assertThat(vd1.calculateDate()).isEqualTo(1l);
 
 
-        VacationDuration vd2 = new VacationDuration(VacationType.MORE_DAY, today, today.plusDays(1l));
+        VacationDuration vd2 = new VacationDuration(today, today.plusDays(1l), LeaveDeduct.DEDUCT);
         assertThat(vd2.calculateDate()).isEqualTo(2l);
 
         LocalDateTime start = LocalDateTime.of(2024, 2, 29, 0, 0);
         LocalDateTime end = LocalDateTime.of(2024, 3, 1, 0, 0);
 
-        VacationDuration vd3 = new VacationDuration(VacationType.MORE_DAY, start, end);
+        VacationDuration vd3 = new VacationDuration(start, end, LeaveDeduct.DEDUCT);
         assertThat(vd3.calculateDate()).isEqualTo(2l);
     }
 
@@ -37,7 +37,7 @@ class VacationDurationTest {
         LocalDateTime start = LocalDateTime.of(2024, 2, 29, 0, 0);
         LocalDateTime end = LocalDateTime.of(2024, 3, 3, 0, 0);
 
-        VacationDuration vd3 = new VacationDuration(VacationType.MORE_DAY, start, end);
+        VacationDuration vd3 = new VacationDuration(start, end, LeaveDeduct.DEDUCT);
         assertThat(vd3.calculateDate()).isEqualTo(2l);
     }
 
@@ -45,7 +45,7 @@ class VacationDurationTest {
     void isInVacationDate() {
         LocalDateTime startDate = LocalDateTime.of(2024, 2, 28, 0, 0);
         LocalDateTime endDate = LocalDateTime.of(2024, 3, 1, 0, 0);
-        VacationDuration vacationDuration = new VacationDuration(VacationType.MORE_DAY, startDate, endDate);
+        VacationDuration vacationDuration = new VacationDuration(startDate, endDate, LeaveDeduct.DEDUCT);
         LocalDateTime betweenDate = LocalDateTime.of(2024, 2, 29, 0, 0);
 
         assertThatThrownBy(() -> vacationDuration.isAlreadyInVacationDate(betweenDate))
@@ -56,7 +56,7 @@ class VacationDurationTest {
     void receiveVacationDateTimes() {
         LocalDateTime startDate = LocalDateTime.of(2024, 2, 28, 0, 0);
         LocalDateTime endDate = LocalDateTime.of(2024, 3, 1, 0, 0);
-        VacationDuration vacationDuration = new VacationDuration(VacationType.MORE_DAY, startDate, endDate);
+        VacationDuration vacationDuration = new VacationDuration(startDate, endDate, LeaveDeduct.DEDUCT);
 
         List<LocalDateTime> localDateTimes = vacationDuration.receiveVacationDateTimes();
 

--- a/vacation-core/src/test/java/com/jxx/vacation/core/vacation/domain/entity/VacationHistoryTest.java
+++ b/vacation-core/src/test/java/com/jxx/vacation/core/vacation/domain/entity/VacationHistoryTest.java
@@ -2,6 +2,7 @@ package com.jxx.vacation.core.vacation.domain.entity;
 
 
 import com.jxx.vacation.core.common.history.HistoryEntityFieldValidator;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -9,10 +10,13 @@ import java.util.Map;
 
 class VacationHistoryTest {
 
+    @DisplayName("연관 관계 매핑을 위한 vacationDurations 필드 제외," +
+            "DEDUCTED_DEFAULT_VALUE 클래스 필드로 제외," +
+            "id 필드 -> 히스토리 앤티티 pk와 분명한 분별을 위해 vacationId 로 변경")
     @Test
-    void test_field() throws NoSuchFieldException {
+    void history_entity_has_required_field() throws NoSuchFieldException {
         HistoryEntityFieldValidator fieldValidator = new HistoryEntityFieldValidator(Vacation.class, VacationHistory.class);
-        fieldValidator.validate(List.of("DEDUCTED_DEFAULT_VALUE"), Map.of("id", "vacationId"));
+        fieldValidator.validate(List.of("DEDUCTED_DEFAULT_VALUE", "vacationDurations"), Map.of("id", "vacationId"));
 
     }
 }

--- a/vacation-core/src/test/java/com/jxx/vacation/core/vacation/domain/entity/VacationManagerTest.java
+++ b/vacation-core/src/test/java/com/jxx/vacation/core/vacation/domain/entity/VacationManagerTest.java
@@ -61,7 +61,7 @@ class VacationManagerTest {
         LocalDateTime endDate2 = LocalDateTime.of(2024, 3, 3, 0, 0);
         List<VacationDuration> vacationDuration2 = List.of(new VacationDuration(startDate2, endDate2, 2f));
 
-        Vacation existedVacation = new Vacation("T0001", "TJX", LeaveDeduct.DEDUCT, vacationDuration2, true, vacationStatus);
+        Vacation existedVacation = new Vacation("T0001", "TJX", LeaveDeduct.DEDUCT, VacationType.MORE_DAY, vacationStatus);
 
         //WHEN - THEN
         assertThatThrownBy(() -> vacationManager.validateVacationDatesAreDuplicated(List.of(existedVacation)))
@@ -90,7 +90,7 @@ class VacationManagerTest {
 
 
         //WHEN - THEN
-        Vacation existedVacation = new Vacation("T0001", "TJX", LeaveDeduct.DEDUCT, vacationDuration2, true, vacationStatus);
+        Vacation existedVacation = new Vacation("T0001", "TJX", LeaveDeduct.DEDUCT, VacationType.MORE_DAY, vacationStatus);
 
         assertThatCode(() -> vacationManager.validateVacationDatesAreDuplicated(List.of(existedVacation)))
                 .doesNotThrowAnyException();
@@ -115,28 +115,16 @@ class VacationManagerTest {
 
         Vacation vacation1 = Vacation.builder()
                 .vacationStatus(VacationStatus.APPROVED)
-                .vacationDurations(List.of(new VacationDuration(
-                        LocalDateTime.of(2024, 6, 1, 0, 0),
-                        LocalDateTime.of(2024, 6, 4, 0, 0),
-                        4f)))
                 .requesterId("T0001")
                 .build();
 
         Vacation vacation2 = Vacation.builder()
                 .vacationStatus(VacationStatus.REQUEST)
-                .vacationDurations(List.of(new VacationDuration(
-                        LocalDateTime.of(2024, 5, 1, 0, 0),
-                        LocalDateTime.of(2024, 5, 4, 0, 0),
-                        4f)))
                 .requesterId("T0001")
                 .build();
 
         Vacation vacation3 = Vacation.builder()
                 .vacationStatus(VacationStatus.REQUEST)
-                .vacationDurations(List.of(new VacationDuration(
-                        LocalDateTime.of(2024, 6, 1, 0, 0),
-                        LocalDateTime.of(2024, 6, 4, 0, 0),
-                        4f)))
                 .requesterId("T0001")
                 .build();
 
@@ -162,32 +150,20 @@ class VacationManagerTest {
 
         Organization organization = CoreEntityFactory.defalutOrganization();
         MemberLeave memberLeave = CoreEntityFactory.defaultMemberLeave(organization); // memberId == requesterId
-        VacationManager vacationManager = VacationManager.create(vacationDuration, VacationType.MORE_DAY, memberLeave);
+        VacationManager vacationManager = VacationManager.create(memberLeave, VacationType.MORE_DAY, LeaveDeduct.DEDUCT);
 
         Vacation vacation1 = Vacation.builder()
                 .vacationStatus(VacationStatus.APPROVED)
-                .vacationDurations(List.of(new VacationDuration(
-                        LocalDateTime.of(2024, 6, 1, 0, 0),
-                        LocalDateTime.of(2024, 6, 4, 0, 0),
-                        4f)))
                 .requesterId("T0001")
                 .build();
 
         Vacation vacation2 = Vacation.builder()
                 .vacationStatus(VacationStatus.REQUEST)
-                .vacationDurations(List.of(new VacationDuration(
-                        LocalDateTime.of(2024, 6, 1, 0, 0),
-                        LocalDateTime.of(2024, 6, 4, 0, 0),
-                        4f)))
                 .requesterId("T0001")
                 .build();
 
         Vacation vacation3 = Vacation.builder()
                 .vacationStatus(VacationStatus.REQUEST)
-                .vacationDurations(List.of(new VacationDuration(
-                        LocalDateTime.of(2024, 6, 1, 0, 0),
-                        LocalDateTime.of(2024, 6, 4, 0, 0),
-                        4f)))
                 .requesterId("T0001")
                 .build();
 

--- a/vacation-core/src/test/java/com/jxx/vacation/core/vacation/domain/entity/VacationManagerTest.java
+++ b/vacation-core/src/test/java/com/jxx/vacation/core/vacation/domain/entity/VacationManagerTest.java
@@ -27,13 +27,13 @@ class VacationManagerTest {
     void instantiate() {
         LocalDateTime startDate = LocalDateTime.now();
         LocalDateTime endDate = LocalDateTime.now().plusDays(2l);
-        VacationDuration vacationDuration = new VacationDuration(VacationType.MORE_DAY, startDate, endDate);
+        List<VacationDuration> vacationDuration = List.of(new VacationDuration(startDate, endDate, 4f));
 
         Organization organization = CoreEntityFactory.defalutOrganization();
         MemberLeave memberLeave = CoreEntityFactory.defaultMemberLeave(organization); // memberId == requesterId
 
         //when
-        VacationManager vacationManager = VacationManager.createVacation(vacationDuration, memberLeave);
+        VacationManager vacationManager = VacationManager.create(memberLeave, VacationType.MORE_DAY, LeaveDeduct.DEDUCT);
 
         assertThat(vacationManager.getVacation()).extracting("requesterId").isEqualTo(memberLeave.getMemberId());
         assertThat(vacationManager.receiveVacationDate()).isEqualTo(3f);
@@ -49,16 +49,17 @@ class VacationManagerTest {
         //given - 휴가 신청
         LocalDateTime startDate = LocalDateTime.of(2024, 3, 1, 0, 0);
         LocalDateTime endDate = LocalDateTime.of(2024, 3, 4, 0, 0);
-        VacationDuration vacationDuration = new VacationDuration(VacationType.MORE_DAY, startDate, endDate);
+        List<VacationDuration> vacationDuration = List.of(new VacationDuration(startDate, endDate, 4f));
 
         Organization organization = CoreEntityFactory.defalutOrganization();
         MemberLeave memberLeave = CoreEntityFactory.defaultMemberLeave(organization); // memberId == requesterId
-        VacationManager vacationManager = VacationManager.createVacation(vacationDuration, memberLeave);
+        VacationManager vacationManager = VacationManager.create(memberLeave, VacationType.MORE_DAY, LeaveDeduct.DEDUCT);
+
 
         // 기존에 존재하고 있는 아직 사용 전인 휴가
         LocalDateTime startDate2 = LocalDateTime.of(2024, 3, 2, 0, 0);
         LocalDateTime endDate2 = LocalDateTime.of(2024, 3, 3, 0, 0);
-        VacationDuration vacationDuration2 = new VacationDuration(VacationType.MORE_DAY, startDate2, endDate2);
+        List<VacationDuration> vacationDuration2 = List.of(new VacationDuration(startDate2, endDate2, 2f));
 
         Vacation existedVacation = new Vacation("T0001", "TJX", LeaveDeduct.DEDUCT, vacationDuration2, true, vacationStatus);
 
@@ -75,16 +76,18 @@ class VacationManagerTest {
     void validate_vacation_dates_are_duplication_not_throw_exception_case(VacationStatus vacationStatus) {
         LocalDateTime startDate = LocalDateTime.of(2024, 3, 1, 0, 0);
         LocalDateTime endDate = LocalDateTime.of(2024, 3, 4, 0, 0);
-        VacationDuration vacationDuration = new VacationDuration(VacationType.MORE_DAY, startDate, endDate);
+        List<VacationDuration> vacationDuration = List.of(new VacationDuration(startDate, endDate, 4f));
 
         Organization organization = CoreEntityFactory.defalutOrganization();
         MemberLeave memberLeave = CoreEntityFactory.defaultMemberLeave(organization); // memberId == requesterId
-        VacationManager vacationManager = VacationManager.createVacation(vacationDuration, memberLeave);
+        VacationManager vacationManager = VacationManager.create(memberLeave, VacationType.MORE_DAY, LeaveDeduct.DEDUCT);
+
 
         // 휴가 상태가 REQUEST, APPROVED, ONGOING 아닌 경우
         LocalDateTime startDate2 = LocalDateTime.of(2024, 3, 2, 0, 0);
         LocalDateTime endDate2 = LocalDateTime.of(2024, 3, 3, 0, 0);
-        VacationDuration vacationDuration2 = new VacationDuration(VacationType.MORE_DAY, startDate2, endDate2);
+        List<VacationDuration> vacationDuration2 = List.of(new VacationDuration(startDate2, endDate2, 2f));
+
 
         //WHEN - THEN
         Vacation existedVacation = new Vacation("T0001", "TJX", LeaveDeduct.DEDUCT, vacationDuration2, true, vacationStatus);
@@ -103,41 +106,38 @@ class VacationManagerTest {
         //GIVEN
         LocalDateTime startDate = LocalDateTime.of(2024, 3, 1, 0, 0);
         LocalDateTime endDate = LocalDateTime.of(2024, 3, 4, 0, 0);
-        VacationDuration vacationDuration = new VacationDuration(VacationType.MORE_DAY, startDate, endDate);
+        List<VacationDuration> vacationDuration = List.of(new VacationDuration(startDate, endDate, 4f));
 
         Organization organization = CoreEntityFactory.defalutOrganization();
         MemberLeave memberLeave = CoreEntityFactory.defaultMemberLeave(organization); // memberId == requesterId
-        VacationManager vacationManager = VacationManager.createVacation(vacationDuration, memberLeave);
+        VacationManager vacationManager = VacationManager.create(memberLeave, VacationType.MORE_DAY, LeaveDeduct.DEDUCT);
+
 
         Vacation vacation1 = Vacation.builder()
                 .vacationStatus(VacationStatus.APPROVED)
-                .vacationDuration(
-                        new VacationDuration(
-                                VacationType.MORE_DAY,
-                                LocalDateTime.of(2024, 4, 1, 0, 0),
-                                LocalDateTime.of(2024, 4, 4, 0, 0)))
+                .vacationDurations(List.of(new VacationDuration(
+                        LocalDateTime.of(2024, 6, 1, 0, 0),
+                        LocalDateTime.of(2024, 6, 4, 0, 0),
+                        4f)))
                 .requesterId("T0001")
-                .deducted(true)
                 .build();
 
         Vacation vacation2 = Vacation.builder()
                 .vacationStatus(VacationStatus.REQUEST)
-                .vacationDuration(new VacationDuration(
-                                VacationType.MORE_DAY,
-                                LocalDateTime.of(2024, 5, 1, 0, 0),
-                                LocalDateTime.of(2024, 5, 4, 0, 0)))
+                .vacationDurations(List.of(new VacationDuration(
+                        LocalDateTime.of(2024, 5, 1, 0, 0),
+                        LocalDateTime.of(2024, 5, 4, 0, 0),
+                        4f)))
                 .requesterId("T0001")
-                .deducted(true)
                 .build();
 
         Vacation vacation3 = Vacation.builder()
                 .vacationStatus(VacationStatus.REQUEST)
-                .vacationDuration(new VacationDuration(
-                                VacationType.MORE_DAY,
-                                LocalDateTime.of(2024, 6, 1, 0, 0),
-                                LocalDateTime.of(2024, 6, 4, 0, 0)))
+                .vacationDurations(List.of(new VacationDuration(
+                        LocalDateTime.of(2024, 6, 1, 0, 0),
+                        LocalDateTime.of(2024, 6, 4, 0, 0),
+                        4f)))
                 .requesterId("T0001")
-                .deducted(true)
                 .build();
 
         List<Vacation> vacations = List.of(vacation1, vacation2, vacation3);
@@ -158,41 +158,37 @@ class VacationManagerTest {
         //GIVEN
         LocalDateTime startDate = LocalDateTime.of(2024, 3, 1, 0, 0);
         LocalDateTime endDate = LocalDateTime.of(2024, 3, endDayOfMonth, 0, 0);
-        VacationDuration vacationDuration = new VacationDuration(VacationType.MORE_DAY, startDate, endDate);
+        List<VacationDuration> vacationDuration = List.of(new VacationDuration(startDate, endDate, 4f));
 
         Organization organization = CoreEntityFactory.defalutOrganization();
         MemberLeave memberLeave = CoreEntityFactory.defaultMemberLeave(organization); // memberId == requesterId
-        VacationManager vacationManager = VacationManager.createVacation(vacationDuration, memberLeave);
+        VacationManager vacationManager = VacationManager.create(vacationDuration, VacationType.MORE_DAY, memberLeave);
 
         Vacation vacation1 = Vacation.builder()
                 .vacationStatus(VacationStatus.APPROVED)
-                .vacationDuration(
-                        new VacationDuration(
-                                VacationType.MORE_DAY,
-                                LocalDateTime.of(2024, 4, 1, 0, 0),
-                                LocalDateTime.of(2024, 4, 4, 0, 0)))
+                .vacationDurations(List.of(new VacationDuration(
+                        LocalDateTime.of(2024, 6, 1, 0, 0),
+                        LocalDateTime.of(2024, 6, 4, 0, 0),
+                        4f)))
                 .requesterId("T0001")
-                .deducted(true)
                 .build();
 
         Vacation vacation2 = Vacation.builder()
                 .vacationStatus(VacationStatus.REQUEST)
-                .vacationDuration(new VacationDuration(
-                        VacationType.MORE_DAY,
-                        LocalDateTime.of(2024, 5, 1, 0, 0),
-                        LocalDateTime.of(2024, 5, 4, 0, 0)))
+                .vacationDurations(List.of(new VacationDuration(
+                        LocalDateTime.of(2024, 6, 1, 0, 0),
+                        LocalDateTime.of(2024, 6, 4, 0, 0),
+                        4f)))
                 .requesterId("T0001")
-                .deducted(true)
                 .build();
 
         Vacation vacation3 = Vacation.builder()
                 .vacationStatus(VacationStatus.REQUEST)
-                .vacationDuration(new VacationDuration(
-                        VacationType.MORE_DAY,
+                .vacationDurations(List.of(new VacationDuration(
                         LocalDateTime.of(2024, 6, 1, 0, 0),
-                        LocalDateTime.of(2024, 6, 4, 0, 0)))
+                        LocalDateTime.of(2024, 6, 4, 0, 0),
+                        4f)))
                 .requesterId("T0001")
-                .deducted(true)
                 .build();
 
         List<Vacation> vacations = List.of(vacation1, vacation2, vacation3);

--- a/vacation-core/src/test/java/com/jxx/vacation/testUtil/CoreEntityFactory.java
+++ b/vacation-core/src/test/java/com/jxx/vacation/testUtil/CoreEntityFactory.java
@@ -20,6 +20,7 @@ public class CoreEntityFactory {
     public static MemberLeave defaultMemberLeave(Organization organization) {
         return MemberLeave.builder()
                 .memberId("T0001")
+                .isActive(true)
                 .name("나재헌")
                 .experienceYears(1)
                 .enteredDate(LocalDate.of(2023, 8, 16))


### PR DESCRIPTION
기존(AS-IS) : Vacation 엔티티, 테이블에서 휴가의 시작일, 종료일인 StartDateTime ,EndDateTime 을 가져가는 구조

변경(TO-BE) Vacation : VacationDuration = 1:N 구조를 가짐

예를 들어 금요일, 월요일을 휴가 신청할 때 금요일부터 월요일까지 하나의 기간으로 신청할 수 있지만 금요일, 월요일을 별개로 신청할 수 도 있다. 이렇게 되면 기간이 2개가 된다. 이에 따라 엔티티 구조를 변경하였다.